### PR TITLE
fix: Return/output correct local port when using --local-port flag

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -133,7 +133,7 @@ func promptForInstanceId(ctx context.Context, api *rds.Client) (rdstypes.DBInsta
 func listenerAndPort(localPort, remotePort int) (net.Listener, int, error) {
 	if localPort != 0 {
 		l, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", localPort))
-		return l, 0, err
+		return l, localPort, err
 	}
 
 	for port := remotePort; port < remotePort+100; port++ {


### PR DESCRIPTION
Thanks for this tool! I often have port 5432 allocated for local development shenanigans, so I tried allocating a different port when connecting to an RDS instance. I got this output:

```
wolfman $ rdsconn proxy --local-port=15432
✔ some-rds-instance
Proxy running. Now waiting to serve connections to localhost:0...
```

Despite the wording, the port that `rdsconn` allocates is in fact 15432, but the `listenerAndPort` function returns 0 so it's not immediately clear. It looks like this returned port value is only used to print out the listening status, so this change should be fairly safe.

Behaviour with this change:

```
wolfman $ rdsconn proxy --local-port=15432
✔ some-rds-instance
Proxy running. Now waiting to serve connections to localhost:15432...
```