### PR TITLE
Provide details when no instance connect endpoints are found

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -67,6 +67,10 @@ func runProxy(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf(": %w", err)
 		}
 
+		if len(describe.InstanceConnectEndpoints) == 0 {
+			return fmt.Errorf("no instance connect endpoints found for vpc %s", vpcId)
+		}
+
 		endpoint := describe.InstanceConnectEndpoints[0]
 		endpointId = *endpoint.InstanceConnectEndpointId
 	}


### PR DESCRIPTION
👋 currently this panics with the following error
```
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.runProxy(0x140001b4300, {0x140001b2350, 0x1, 0x1?})
        /home/runner/work/rdsconn/rdsconn/proxy.go:70 +0x8f0
github.com/spf13/cobra.(*Command).execute(0x140001b4300, {0x140001b2310, 0x1, 0x1})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:940 +0x5c8
github.com/spf13/cobra.(*Command).ExecuteC(0x140001b4000)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:985
main.main()
        /home/runner/work/rdsconn/rdsconn/main.go:28 +0x188
```

This updates to tell the user there's no instance connect endpoints in the vpc
```
panic: no instance connect endpoints found for vpc vpc-073xxxxxx

goroutine 1 [running]:
main.main()
        /Users/conor.mongey/workspace/Mongey/rdsconn/main.go:30 +0x1dc
```